### PR TITLE
Upgrade PowerDNS to 4.3 and use Debian Stretch as base image

### DIFF
--- a/docker/powerdns/Dockerfile
+++ b/docker/powerdns/Dockerfile
@@ -1,7 +1,7 @@
-FROM buildpack-deps:jessie-scm
+FROM buildpack-deps:stretch-scm
 
-# the setup procedure according to https://repo.powerdns.com/ (Debian 8 Jessie)
-RUN echo "deb http://repo.powerdns.com/debian jessie-auth-41 main" > /etc/apt/sources.list.d/pdns.list \
+# the setup procedure according to https://repo.powerdns.com/ (Debian 9 Stretch)
+RUN echo "deb [arch=amd64] http://repo.powerdns.com/debian stretch-auth-43 main" > /etc/apt/sources.list.d/pdns.list \
 	&& echo "Package: pdns-*\nPin: origin repo.powerdns.com\nPin-Priority: 600\n" >> /etc/apt/preferences.d/pdns \
 	&& curl https://repo.powerdns.com/FD380FBB-pub.asc | apt-key add - \
 	&& apt-get -y update \

--- a/docker/powerdns/pdns.conf
+++ b/docker/powerdns/pdns.conf
@@ -1,4 +1,3 @@
-disable-tcp=yes
 cache-ttl=0
 loglevel=7
 log-dns-details=yes


### PR DESCRIPTION
Upgrade PowerDNS to 4.3 and use Debian Stretch as base image because 4.1 packages deliver 404 responses for Debian Jessie (#21 ). The PowerDNS config option [`disable-tcp`](https://doc.powerdns.com/authoritative/settings.html#disable-tcp) was removed and is not supported anymore.