### PR TITLE
Fix bug where X-Forwarded-For is returned as one string

### DIFF
--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -122,7 +122,7 @@ func (f *Frontend) Run() error {
 
 		c.JSON(200, gin.H{
 			"current_ip": ip,
-			"status":     "Successfuly updated",
+			"status":     "Successfully updated",
 		})
 	})
 

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"regexp"
+	"strings"
 )
 
 type Frontend struct {
@@ -132,10 +133,14 @@ func (f *Frontend) Run() error {
 // X-Forwarded-For Header which holds the IP if we are behind a proxy,
 // otherwise the RemoteAddr is used
 func extractRemoteAddr(req *http.Request) (string, error) {
-	header_data, ok := req.Header["X-Forwarded-For"]
+	headerData, ok := req.Header["X-Forwarded-For"]
 
 	if ok {
-		return header_data[0], nil
+		//Cloudflare returns it as a string. Haven't tested others
+		//You end up getting "ip1, ip2" instead of ip1.
+		//So we split it and take the first
+		cleanedString := strings.Split(headerData[0], ", ")[0]
+		return cleanedString, nil
 	} else {
 		ip, _, err := net.SplitHostPort(req.RemoteAddr)
 		return ip, err

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -136,7 +136,8 @@ func extractRemoteAddr(req *http.Request) (string, error) {
 	headerData, ok := req.Header["X-Forwarded-For"]
 
 	if ok {
-		//Cloudflare returns it as a string. Haven't tested others
+		//headerData[0] is one long string with
+		//all ips and not just the first one
 		//You end up getting "ip1, ip2" instead of ip1.
 		//So we split it and take the first
 		cleanedString := strings.Split(headerData[0], ", ")[0]


### PR DESCRIPTION
I ran this behind cloudflare, and noticed that when you do a curl update it returned:
{"current_ip":"xxx.xx.xxx.xx, xxx.xxx.xx.xxx","status":"Successfully updated"}
instead of
{"current_ip":"xxx.xx.xxx.xx","status":"Successfully updated"}

This was happening because 
`headerData, ok := req.Header["X-Forwarded-For"]`
headerData[0] was returning both ips as one long string and not just the first ip

I added a small check that takes only the first IP.