### PR TITLE
Add DDNS_EXPIRATION_DAYS env variable

### DIFF
--- a/docker/ddns/Dockerfile
+++ b/docker/ddns/Dockerfile
@@ -9,5 +9,10 @@ RUN GO111MODULE=on go get -d -v ./...
 RUN GO111MODULE=on go install -v ./...
 
 ENV GIN_MODE release
+ENV DDNS_EXPIRATION_DAYS 10
 
-CMD /go/bin/ddns --domain=${DDNS_DOMAIN} --soa_fqdn=${DDNS_SOA_DOMAIN} --redis=${DDNS_REDIS_HOST}
+CMD /go/bin/ddns \
+    --domain=${DDNS_DOMAIN} \
+    --soa_fqdn=${DDNS_SOA_DOMAIN} \
+    --redis=${DDNS_REDIS_HOST} \
+    --expiration-days=${DDNS_EXPIRATION_DAYS}

--- a/docker/docker-compose.override.yml.sample
+++ b/docker/docker-compose.override.yml.sample
@@ -5,6 +5,7 @@ services:
     environment:
       DDNS_DOMAIN: d.example.net                      # <<< ADJUST DOMAIN
       DDNS_SOA_DOMAIN: ddns.example.net               # <<< ADJUST DOMAIN
+      DDNS_EXPIRATION_DAYS: 10
 
   powerdns:
     ports:


### PR DESCRIPTION
Hi,

this is just a small change in the dockerfile to allow passing a value for `--expiration-days` via the `DDNS_EXPIRATION_DAYS` environment variable, to make it more convenient for users to override.

Best, Thomas