### PR TITLE
Update hostname regex to accept "-"

### DIFF
--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -153,7 +153,7 @@ func buildTemplate() *template.Template {
 }
 
 func isValidHostname(host string) (string, bool) {
-	valid, _ := regexp.Match("^[a-z0-9]{1,32}$", []byte(host))
+	valid, _ := regexp.Match("^([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)$", []byte(host))
 
 	return host, valid
 }


### PR DESCRIPTION
Hi,

I found the front end UI doesn't accept hostname with "-", I would like to have that in some of my hostnames so I did this fix.
Please feel free to comment.
Thanks!

Updated hostname regex to accept "-" according to RFC 1123
Ref: https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address