### PR TITLE
Allow turning on --verbose mode by environment variable $DEBUG_MODE

### DIFF
--- a/docker/ddns/Dockerfile
+++ b/docker/ddns/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:alpine
 
 RUN apk add --no-cache git
 
+COPY docker/ddns/entrypoint.sh /entrypoint.sh
 WORKDIR /go/src/github.com/pboehm/ddns
 COPY . .
 
@@ -11,8 +12,4 @@ RUN GO111MODULE=on go install -v ./...
 ENV GIN_MODE release
 ENV DDNS_EXPIRATION_DAYS 10
 
-CMD /go/bin/ddns \
-    --domain=${DDNS_DOMAIN} \
-    --soa_fqdn=${DDNS_SOA_DOMAIN} \
-    --redis=${DDNS_REDIS_HOST} \
-    --expiration-days=${DDNS_EXPIRATION_DAYS}
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/ddns/entrypoint.sh
+++ b/docker/ddns/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+if [[ $# -eq 0 ]]; then
+
+    if [[ "${DEBUG_MODE:-false}" == "true" ]]; then
+        /go/bin/ddns \
+            --domain=${DDNS_DOMAIN} \
+            --soa_fqdn=${DDNS_SOA_DOMAIN} \
+            --redis=${DDNS_REDIS_HOST} \
+            --expiration-days=${DDNS_EXPIRATION_DAYS} \
+            --verbose
+    else
+	 /go/bin/ddns \
+            --domain=${DDNS_DOMAIN} \
+            --soa_fqdn=${DDNS_SOA_DOMAIN} \
+            --redis=${DDNS_REDIS_HOST} \
+            --expiration-days=${DDNS_EXPIRATION_DAYS}
+    fi
+
+else
+    "$@"
+fi

--- a/docker/docker-compose.override.yml.sample
+++ b/docker/docker-compose.override.yml.sample
@@ -6,6 +6,7 @@ services:
       DDNS_DOMAIN: d.example.net                      # <<< ADJUST DOMAIN
       DDNS_SOA_DOMAIN: ddns.example.net               # <<< ADJUST DOMAIN
       DDNS_EXPIRATION_DAYS: 10
+      DEBUG_MODE: "false"
 
   powerdns:
     ports:


### PR DESCRIPTION
Hi,

I found it's a bit trouble to turn on the -verbose switch with docker-compose as the start-up command is hard-coded during docker build. I've transfer the start-up commands into an entrypoint script and allow starting other commands for troubleshooting.

Hope it helps

-----------------
- Run application by an entrypoint.sh script to allow more debug options